### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/jaredfolkins/badactor"
 	"github.com/julienschmidt/httprouter"
 )


### PR DESCRIPTION
github.com/codegangsta/negroni is now github.com/urfave/negroni. 
Github will redirect, but change is suggested for clarity