### PR TITLE
Make 'Name' field accessible

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -43,6 +43,13 @@ func newClassicActor(n string, r *Rule, d *Director) *Actor {
 	return a
 }
 
+func (a *Actor) Name() string {
+	a.director.Lock()
+	defer a.director.Unlock()
+
+	return a.name
+}
+
 func (a *Actor) rebaseAll() error {
 
 	/* I don't believe this is needed, tests pass, will think a bit more before removing

--- a/actor.go
+++ b/actor.go
@@ -9,7 +9,7 @@ import (
 const ttl = 100
 
 type Actor struct {
-	name        string
+	Name        string
 	infractions map[string]*infraction
 	jails       map[string]*jail
 	director    *Director
@@ -21,7 +21,7 @@ func newActor(n string, d *Director) *Actor {
 	a := &Actor{
 		director:    d,
 		ttl:         time.Now().Add(time.Millisecond * ttl),
-		name:        n,
+		Name:        n,
 		infractions: make(map[string]*infraction),
 		jails:       make(map[string]*jail),
 		accessedAt:  time.Now(),
@@ -33,7 +33,7 @@ func newClassicActor(n string, r *Rule, d *Director) *Actor {
 	a := &Actor{
 		director:    d,
 		ttl:         time.Now().Add(time.Millisecond * ttl),
-		name:        n,
+		Name:        n,
 		infractions: make(map[string]*infraction),
 		jails:       make(map[string]*jail),
 		accessedAt:  time.Now(),
@@ -59,7 +59,7 @@ func (a *Actor) rebaseAll() error {
 func (a *Actor) infraction(rn string) error {
 
 	if a.isJailedFor(rn) {
-		return fmt.Errorf("actor [%v] is already Jailed for [%v]", a.name, rn)
+		return fmt.Errorf("actor [%v] is already Jailed for [%v]", a.Name, rn)
 	}
 
 	if _, ok := a.infractions[rn]; ok {
@@ -69,7 +69,7 @@ func (a *Actor) infraction(rn string) error {
 		return a.jail(rn)
 	}
 
-	return fmt.Errorf("Infraction against actor [%v]", a.name)
+	return fmt.Errorf("Infraction against actor [%v]", a.Name)
 }
 
 func (a *Actor) strikes(rn string) int {

--- a/actor.go
+++ b/actor.go
@@ -9,7 +9,7 @@ import (
 const ttl = 100
 
 type Actor struct {
-	Name        string
+	name        string
 	infractions map[string]*infraction
 	jails       map[string]*jail
 	director    *Director
@@ -21,7 +21,7 @@ func newActor(n string, d *Director) *Actor {
 	a := &Actor{
 		director:    d,
 		ttl:         time.Now().Add(time.Millisecond * ttl),
-		Name:        n,
+		name:        n,
 		infractions: make(map[string]*infraction),
 		jails:       make(map[string]*jail),
 		accessedAt:  time.Now(),
@@ -33,7 +33,7 @@ func newClassicActor(n string, r *Rule, d *Director) *Actor {
 	a := &Actor{
 		director:    d,
 		ttl:         time.Now().Add(time.Millisecond * ttl),
-		Name:        n,
+		name:        n,
 		infractions: make(map[string]*infraction),
 		jails:       make(map[string]*jail),
 		accessedAt:  time.Now(),
@@ -59,7 +59,7 @@ func (a *Actor) rebaseAll() error {
 func (a *Actor) infraction(rn string) error {
 
 	if a.isJailedFor(rn) {
-		return fmt.Errorf("actor [%v] is already Jailed for [%v]", a.Name, rn)
+		return fmt.Errorf("actor [%v] is already Jailed for [%v]", a.name, rn)
 	}
 
 	if _, ok := a.infractions[rn]; ok {
@@ -69,7 +69,7 @@ func (a *Actor) infraction(rn string) error {
 		return a.jail(rn)
 	}
 
-	return fmt.Errorf("Infraction against actor [%v]", a.Name)
+	return fmt.Errorf("Infraction against actor [%v]", a.name)
 }
 
 func (a *Actor) strikes(rn string) int {

--- a/actor_test.go
+++ b/actor_test.go
@@ -480,3 +480,27 @@ func TestActorTotalJails(t *testing.T) {
 	}
 
 }
+
+func TestActorName(t *testing.T) {
+	// setup
+	d := NewDirector(ia)
+	an := "an_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	rn := "rn_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	rm := "rm_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	sl := 3
+	r := &Rule{
+		Name:        rn,
+		Message:     rm,
+		StrikeLimit: sl,
+		ExpireBase:  time.Second * 60,
+		Sentence:    time.Second * 60,
+		Action:      &ActorMockAction{},
+	}
+	a := newClassicActor(an, r, d)
+
+	// test
+	name := a.Name()
+	if name != an {
+		t.Errorf("Name() should be %s instead [%s]", an, name)
+	}
+}

--- a/director.go
+++ b/director.go
@@ -34,7 +34,7 @@ func (d *Director) lMaintenance() {
 	d.Lock()
 	defer d.Unlock()
 	for e := d.index.Front(); e != nil; e = e.Next() {
-		an := e.Value.(*Actor).name
+		an := e.Value.(*Actor).Name
 		d.maintenance(an)
 	}
 }
@@ -188,7 +188,7 @@ func (d *Director) maintenance(an string) {
 			a.expire(inf.rule.Name)
 		}
 		if a.shouldDelete() {
-			delete(d.actors, a.name)
+			delete(d.actors, a.Name)
 			d.size--
 		}
 	}
@@ -213,7 +213,7 @@ func (d *Director) deleteOldest() {
 		e := d.index.Back()
 		a := e.Value.(*Actor)
 		d.index.Remove(e)
-		delete(d.actors, a.name)
+		delete(d.actors, a.Name)
 		d.size--
 	}
 }

--- a/director.go
+++ b/director.go
@@ -34,7 +34,7 @@ func (d *Director) lMaintenance() {
 	d.Lock()
 	defer d.Unlock()
 	for e := d.index.Front(); e != nil; e = e.Next() {
-		an := e.Value.(*Actor).Name
+		an := e.Value.(*Actor).name
 		d.maintenance(an)
 	}
 }
@@ -188,7 +188,7 @@ func (d *Director) maintenance(an string) {
 			a.expire(inf.rule.Name)
 		}
 		if a.shouldDelete() {
-			delete(d.actors, a.Name)
+			delete(d.actors, a.name)
 			d.size--
 		}
 	}
@@ -213,7 +213,7 @@ func (d *Director) deleteOldest() {
 		e := d.index.Back()
 		a := e.Value.(*Actor)
 		d.index.Remove(e)
-		delete(d.actors, a.Name)
+		delete(d.actors, a.name)
 		d.size--
 	}
 }


### PR DESCRIPTION
# The Problem

In the `Action` interface, both attached functions receive an `Actor` and a `Rule`. While this is useful for things like contextual logging, there's no way to extract the actor name since it's not publicly exported. 

# The Solution

In this PR, the `Actor.name` field is renamed to `Name`. That way it becomes gettable for structs that implement `Action` interface.

If we really want to keep the name private, we can instead add a `GetName` getter function to the struct that just returns a copy of the name. However, that seems like overkill.

# Related Issues

Closes #6 